### PR TITLE
Allow variable numbers of answers and prompt improvements

### DIFF
--- a/app/components/PollForm.tsx
+++ b/app/components/PollForm.tsx
@@ -60,24 +60,12 @@ const PollForm: React.FC<PollFormProps> = ({ onClose }) => {
 				{
 					text: questionData?.question || '',
 					type: 'single-choice' as HMSPollQuestionType,
-					options: [
-						{
-							text: questionData?.options[0] || '',
+					options: questionData.options.map((option: string) => {
+						return {
+							text: option,
 							isCorrectAnswer: false,
-						},
-						{
-							text: questionData?.options[1] || '',
-							isCorrectAnswer: false,
-						},
-						{
-							text: questionData?.options[2] || '',
-							isCorrectAnswer: false,
-						},
-						{
-							text: questionData?.options[3] || '',
-							isCorrectAnswer: false,
-						},
-					],
+						}
+					}),
 					skippable: true,
 				},
 			])

--- a/app/components/PollVotes.tsx
+++ b/app/components/PollVotes.tsx
@@ -6,17 +6,20 @@ export const PollVotes = ({ poll }: { poll: HMSPoll }) => {
 	const hmsActions = useHMSActions()
 	const question = poll.questions?.[0]
 	const responses = question?.responses
-	const [voteCount, setVoteCount] = useState([0, 0, 0, 0])
+	const [voteCount, setVoteCount] = useState<number[]>([])
 	const totalCount = voteCount.reduce((sum, value) => (sum += value), 0)
 	const localPeerId = useHMSStore(selectLocalPeerID)
 	const showEndPollButton = localPeerId === poll.startedBy
 
 	useEffect(() => {
-		const newVoteCount = [0, 0, 0, 0]
+		const newVoteCount = question.options.map(() => 0)
 		// Option index starts from 1
-		responses?.forEach((response) => newVoteCount[response.option - 1]++)
+		responses?.forEach((response) => {
+			const count = newVoteCount[response.option - 1] ?? 0
+			newVoteCount[response.option - 1] = count + 1
+		})
 		setVoteCount(newVoteCount)
-	}, [responses])
+	}, [responses, question])
 
 	return (
 		<div

--- a/app/makeReal.tsx
+++ b/app/makeReal.tsx
@@ -8,8 +8,12 @@ import {
 	fetchFromOpenAi,
 } from './lib/fetchFromOpenAi'
 
-const SYSTEM_PROMPT = `You are expert at engaging audience through interative polls and quizzes. Your job is to accept a drawing or an image and generate a poll with multiple options for the attendees to vote on to make a session more interative. For example, if there a 2 + 2 question generate the correct answer which is 4 and three other options which could be 2,3,5, etc
-	When sent new image as input, respond ONLY with the a json of question and array called options with 4 string values without any words like "json" or characters like "\`".`
+const SYSTEM_PROMPT = `You are an expert at constructing interative polls and quizzes for audiences.
+Your job is to accept a design and turn it into a poll with multiple options for attendees to vote on to make a session more interative.
+The poll must closely match the image you've been sent. Use the exact question and answers from the image. If the question or answers are missing, come up with those yourself so that they closely match the image.
+For example, if you receive an image asking the user to pick their food, and a drawing of a banana, an apple, and a pear, the three options will be Banana, Apple, and Pear.
+Some of the images and polls may be unusual. That's ok! The goal is to make the poll as close to the image as possible, and have some fun. If the image shows some creativity and humor, feel free to match that creativity and humor in the poll. For example, there might be a clear non-food in the previous example design, and instead the image contains a drawing of planet earth. If that's the case, it's ok! The options will be Banana, Apple, Pear, and Planet Earth.
+When sent new image as input, respond ONLY with the a json of question and array called options with between 2 and 10 string values without any words like "json" or characters like "\`".`
 
 export async function makeReal(
 	editor: Editor,


### PR DESCRIPTION
This PR allows for a variable number of poll answers between 2 and 10. This is useful for yes/no questions, or questions with more than 4 answers.

This PR also adjusts the prompt so that the generated poll better takes into account the user's own suggested answers.